### PR TITLE
fixbug with eager root where

### DIFF
--- a/src/lib/FilterQueryBuilder.js
+++ b/src/lib/FilterQueryBuilder.js
@@ -187,7 +187,7 @@ const applyRequire = function (filter = {}, builder, utils) {
       throw new Error('Filter is invalid');
     }
   });
-  const getFullyQualifiedName = name => sliceRelation(name).fullyQualifiedProperty;
+  const getFullyQualifiedName = name => sliceRelation(name, '.', Model.tableName).fullyQualifiedProperty;
 
   const Model = builder.modelClass();
   const idColumns = _.isArray(Model.idColumn) ? Model.idColumn : [Model.idColumn];

--- a/src/lib/LogicalIterator.js
+++ b/src/lib/LogicalIterator.js
@@ -98,6 +98,7 @@ const iterateLogicalExpression = function({
           });
         } else {
           // The lhs is either a non-logical operator or a property name
+          debug('onExit', propertyTransform(lhs), rhs)
           onExit(propertyTransform(lhs), rhs, subQueryBuilder);
         }
       }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -14,7 +14,7 @@ const { iterateLogicalExpression } = require('./LogicalIterator');
  * @param {String} relatedProperty A dot notation property "a.b.c"
  * @param {String} delimiter A delimeter to use on the relation e.g. "." or ":"
  */
-const sliceRelation = (relatedProperty, delimiter = '.') => {
+const sliceRelation = (relatedProperty, delimiter = '.', rootTableName) => {
   const split = relatedProperty.split('.');
   const propertyName = split[split.length - 1];
   const relationName = split.slice(0, split.length - 1).join(delimiter);
@@ -23,7 +23,7 @@ const sliceRelation = (relatedProperty, delimiter = '.') => {
   // https://github.com/Vincit/objection.js/issues/363
   const fullyQualifiedProperty = relationName ?
     `${relationName.replace(/\./g, ':')}.${propertyName}` :
-    propertyName;
+    rootTableName ? `${rootTableName}.${propertyName}`:propertyName;
 
   return { propertyName, relationName, fullyQualifiedProperty };
 };

--- a/test/eager.test.js
+++ b/test/eager.test.js
@@ -323,6 +323,23 @@ describe('eager object notation', function () {
             'F09'
           ]);
         });
+
+        it('should filter using root field', async function() {
+          const result = await buildFilter(Person)
+            .build({
+              eager: {
+                $where: {
+                  id: {
+                    $gt: 0
+                  },
+                  'pets.name': 'P90'
+                }
+              }
+            });
+          result.map(item => item.firstName).should.deep.equal([
+            'F09'
+          ]);
+        });
       });
 
       describe('eager models using related fields', function() {


### PR DESCRIPTION
fixbug
```
buildFilter(Person)
  .build({
    eager: {
      $where: {
        id: {
          $gt: 0
        },
        'pets.name': 'P90'
      }
     }
   })
eager object notation sqlite3 root model using related fields should filter using root field:
     select `Person`.* from `Person` inner join (select distinct `Person`.`id` from `Person` inner join `Animal` as `pets` on `pets`.`ownerId` = `Person`.`id` where (`id` > 0 and `pets`.`name` = 'P90')) a
s `filter_query` on `Person`.`id` = `filter_query`.`id` - SQLITE_ERROR: ambiguous column name: id
```