### PR TITLE
Support Node 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
   - '10'
   - '12'
+  - '14'
 services:
   - postgresql
   - mysql

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "engines": {
-    "node": ">=10.0.0 <=12.x.x"
+    "node": ">=10.0.0 <= 14.x.x"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
As far as I can tell, this package works in Node 14 but the package.json does not list it as a supported version. This makes the package break when someone uses yarn.