### PR TITLE
Optional `trx` and `options` initializers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,8 @@ import { getPropertiesFromExpression as _getPropertiesFromExpression } from './l
 
 export function buildFilter<M extends BaseModel, K extends typeof Model>(
   modelClass: K,
-  trx: Transaction,
-  options: FilterQueryBuilderOptions<M>
+  trx?: Transaction,
+  options?: FilterQueryBuilderOptions<M>
 ): _FilterQueryBuilder<M, K> {
   return new FilterQueryBuilder(modelClass, trx, options);
 }

--- a/src/lib/FilterQueryBuilder.ts
+++ b/src/lib/FilterQueryBuilder.ts
@@ -71,7 +71,7 @@ export default class FilterQueryBuilder<
    */
   constructor(
     Model: K,
-    trx: Transaction,
+    trx?: Transaction,
     options: FilterQueryBuilderOptions<M> = {}
   ) {
     this.Model = Model;


### PR DESCRIPTION
Noticed that in our TS project, we were required to initialize `buildFilter` with all three of its arguments

<img width="511" alt="Screen Shot 2022-04-03 at 4 25 11 PM" src="https://user-images.githubusercontent.com/12371411/161453428-8c8a5038-de25-43da-a7db-a986a2d3ecfd.png">

as `buildFilter(Model, undefined, undefined)`, instead of just `buildFilter(Model)`, like in the docs example

PR tested by running `tsc --noEmit`