### PR TITLE
Adds builder param to the buildFilter method so user can pass custom builder

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,9 +9,8 @@ export function buildFilter<M extends BaseModel, K extends typeof Model>(
   modelClass: K,
   trx?: Transaction,
   options?: FilterQueryBuilderOptions<M>,
-  builder?: QueryBuilder<M>,
 ): _FilterQueryBuilder<M, K> {
-  return new FilterQueryBuilder(modelClass, trx, options, builder);
+  return new FilterQueryBuilder(modelClass, trx, options);
 }
 export const FilterQueryBuilder = _FilterQueryBuilder;
 export const sliceRelation = _sliceRelation;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Transaction, Model } from 'objection';
+import { Transaction, Model, QueryBuilder } from 'objection';
 import _FilterQueryBuilder from './lib/FilterQueryBuilder';
 import { sliceRelation as _sliceRelation } from './lib/utils';
 import { createRelationExpression as _createRelationExpression } from './lib/ExpressionBuilder';
@@ -8,9 +8,10 @@ import { getPropertiesFromExpression as _getPropertiesFromExpression } from './l
 export function buildFilter<M extends BaseModel, K extends typeof Model>(
   modelClass: K,
   trx?: Transaction,
-  options?: FilterQueryBuilderOptions<M>
+  options?: FilterQueryBuilderOptions<M>,
+  builder?: QueryBuilder<M>,
 ): _FilterQueryBuilder<M, K> {
-  return new FilterQueryBuilder(modelClass, trx, options);
+  return new FilterQueryBuilder(modelClass, trx, options, builder);
 }
 export const FilterQueryBuilder = _FilterQueryBuilder;
 export const sliceRelation = _sliceRelation;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Transaction, Model, QueryBuilder } from 'objection';
+import { Transaction, Model } from 'objection';
 import _FilterQueryBuilder from './lib/FilterQueryBuilder';
 import { sliceRelation as _sliceRelation } from './lib/utils';
 import { createRelationExpression as _createRelationExpression } from './lib/ExpressionBuilder';
@@ -8,7 +8,7 @@ import { getPropertiesFromExpression as _getPropertiesFromExpression } from './l
 export function buildFilter<M extends BaseModel, K extends typeof Model>(
   modelClass: K,
   trx?: Transaction,
-  options?: FilterQueryBuilderOptions<M>,
+  options?: FilterQueryBuilderOptions<M>
 ): _FilterQueryBuilder<M, K> {
   return new FilterQueryBuilder(modelClass, trx, options);
 }

--- a/src/lib/FilterQueryBuilder.ts
+++ b/src/lib/FilterQueryBuilder.ts
@@ -68,14 +68,16 @@ export default class FilterQueryBuilder<
    * @param {Model} Model
    * @param {Transaction} trx
    * @param {Object} options.operators Custom operator handlers
+   * @param {QueryBuilder} builder Custom builder
    */
   constructor(
     Model: K,
     trx?: Transaction,
-    options: FilterQueryBuilderOptions<M> = {}
+    options: FilterQueryBuilderOptions<M> = {},
+    builder?: QueryBuilder<M>,
   ) {
     this.Model = Model;
-    this._builder = Model.query(trx) as QueryBuilder<M>;
+    this._builder = builder || Model.query(trx) as QueryBuilder<M>;
 
     const { operators = {}, onAggBuild } = options;
 

--- a/src/lib/FilterQueryBuilder.ts
+++ b/src/lib/FilterQueryBuilder.ts
@@ -68,18 +68,16 @@ export default class FilterQueryBuilder<
    * @param {Model} Model
    * @param {Transaction} trx
    * @param {Object} options.operators Custom operator handlers
-   * @param {QueryBuilder} builder Custom builder
    */
   constructor(
     Model: K,
     trx?: Transaction,
     options: FilterQueryBuilderOptions<M> = {},
-    builder?: QueryBuilder<M>,
   ) {
+    const { operators = {}, onAggBuild, builder } = options;
+
     this.Model = Model;
     this._builder = builder || Model.query(trx) as QueryBuilder<M>;
-
-    const { operators = {}, onAggBuild } = options;
 
     // Initialize instance specific utilities
     this.utils = Operations({ operators, onAggBuild });

--- a/src/lib/FilterQueryBuilder.ts
+++ b/src/lib/FilterQueryBuilder.ts
@@ -72,7 +72,7 @@ export default class FilterQueryBuilder<
   constructor(
     Model: K,
     trx?: Transaction,
-    options: FilterQueryBuilderOptions<M> = {},
+    options: FilterQueryBuilderOptions<M> = {}
   ) {
     const { operators = {}, onAggBuild, builder } = options;
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -73,6 +73,7 @@ export interface LogicalExpressionIteratorOptions<M extends Model> {
 export interface FilterQueryBuilderOptions<M extends Model> {
   operators?: Operators<M>;
   onAggBuild?: AggregationCallback;
+  builder?: QueryBuilder<M>;
 }
 
 export interface FilterQueryParams {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -147,7 +147,7 @@ describe('basic filters', function () {
 
         it('should order by property added in model modifier', async () => {
           const builder = Person.query().modify("withBirthYear");
-          const result = await buildFilter(Person, null, {}, builder)
+          const result = await buildFilter(Person, null, { builder })
             .build({
               order: 'birthYear, id'
             });

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,6 +1,5 @@
 const _ = require('lodash');
 require('chai').should();
-const { raw, ref } = require('objection');
 const testUtils = require('./utils');
 const { buildFilter } = require('../dist');
 

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 require('chai').should();
+const { raw, ref } = require('objection');
 const testUtils = require('./utils');
 const { buildFilter } = require('../dist');
 
@@ -141,6 +142,17 @@ describe('basic filters', function () {
             });
           result.map(item => item.id).should.deep.equal(
             _.sortBy(result, ['seq', 'id']).map(({ id }) => id)
+          );
+        });
+
+        it('should order by property added in model modifier', async () => {
+          const builder = Person.query().modify("withBirthYear");
+          const result = await buildFilter(Person, null, {}, builder)
+            .build({
+              order: 'birthYear, id'
+            });
+          result.map(item => item.id).should.deep.equal(
+            _.sortBy(result, ['birthYear', 'id']).map(({ id }) => id)
           );
         });
       });

--- a/test/utils.js
+++ b/test/utils.js
@@ -5,6 +5,7 @@ const Knex = require('knex');
 const Promise = require('bluebird');
 const objection = require('objection');
 const pg = require('pg');
+const { raw } = require('objection');
 
 pg.types.setTypeParser(1700, 'text', parseFloat); // DECIMAL
 pg.types.setTypeParser(20, 'text', parseInt); // BIGINT
@@ -255,6 +256,19 @@ function createModels(knex) {
   class Person extends objection.Model {
     static get tableName() {
       return 'Person';
+    }
+
+    static get modifiers() {
+      return {
+        withBirthYear(builder) {
+          const currentYear = new Date().getFullYear();
+          const personWithBirthYearQuery = Person.query().withGraphFetched("movies").select([
+            "Person.id", 
+            raw(`${currentYear} - age`).as("birthYear"),
+          ]);
+          builder.from(raw("(??)", personWithBirthYearQuery).as("Person"));
+        },
+      };
     }
 
     static get relationMappings() {


### PR DESCRIPTION
Issue #60.

Allows user to pass a custom builder as a parameter of `buildFilter`. Here's an example of how it'd help.

Person has `withBirthYear` modifier that adds `birthYear` column. 

```javascript
class Person extends objection.Model {
    static get tableName() {
      return 'Person';
    }

    static get modifiers() {
      return {
        withBirthYear(builder) {
          const currentYear = new Date().getFullYear();
          const personWithBirthYearQuery = Person.query().withGraphFetched("movies").select([
            "Person.id", 
            raw(`${currentYear} - age`).as("birthYear"),
          ]);
          builder.from(raw("(??)", personWithBirthYearQuery).as("Person"));
        },
      };
    }
```
Then it'd be possible to order `Person` by `birthYear` like this.

```javascript
const builder = Person.query().modify("withBirthYear");
const result = await buildFilter(Person, null, {}, builder)
  .build({
    order: 'birthYear, id'
  });
```