### PR TITLE
Ensures builder context is used in all generated queries 

### DIFF
--- a/src/lib/FilterQueryBuilder.ts
+++ b/src/lib/FilterQueryBuilder.ts
@@ -217,7 +217,9 @@ const buildAggregation = function <M extends BaseModel>(
         columnAlias
       ])
     )
-    .leftJoinRelated(relation);
+    .leftJoinRelated(relation)
+	.context(builder.context());
+
 
   // Apply filters to models on the aggregation path
   if (onAggBuild) {
@@ -243,7 +245,7 @@ const buildAggregation = function <M extends BaseModel>(
   }
 
   // Apply the filtering using the outer model as a starting point
-  const filterQuery = OuterModel.query();
+  const filterQuery = OuterModel.query().context(builder.context());
   applyRequire($where, filterQuery, utils);
   const filterQueryAlias = 'filter_query';
   aggregationQuery.innerJoin(filterQuery.as(filterQueryAlias), function () {
@@ -276,7 +278,10 @@ const applyAggregations = function <M extends BaseModel>(
   );
 
   // Create a replicated subquery equivalent to the base model + aggregations
-  const fullQuery = Model.query().select(Model.tableName + '.*');
+  const fullQuery = Model.query()
+  	.select(Model.tableName + '.*')
+	.context(builder.context());
+
 
   // For each aggregation query, select the aggregation then join onto the full query
   aggregationQueries.forEach((query, i) => {
@@ -483,10 +488,9 @@ export function applyRequire<M extends BaseModel>(
   }
 
   // If there are a hasMany or manyToMany relations, then create a separate filter query
-  const filterQuery = Model.query().distinct(...fullIdColumns);
-  
-  	// Uncomment to fix: 
-    // filterQuery.context(builder.context());
+  const filterQuery = Model.query()
+  	.distinct(...fullIdColumns)
+    .context(builder.context());
 
   applyLogicalExpression(filter, filterQuery, false, getFullyQualifiedName);
 

--- a/src/lib/FilterQueryBuilder.ts
+++ b/src/lib/FilterQueryBuilder.ts
@@ -484,6 +484,10 @@ export function applyRequire<M extends BaseModel>(
 
   // If there are a hasMany or manyToMany relations, then create a separate filter query
   const filterQuery = Model.query().distinct(...fullIdColumns);
+  
+  	// Uncomment to fix: 
+    // filterQuery.context(builder.context());
+
   applyLogicalExpression(filter, filterQuery, false, getFullyQualifiedName);
 
   // If there were related properties, join onto the filter

--- a/src/lib/FilterQueryBuilder.ts
+++ b/src/lib/FilterQueryBuilder.ts
@@ -218,8 +218,7 @@ const buildAggregation = function <M extends BaseModel>(
       ])
     )
     .leftJoinRelated(relation)
-	.context(builder.context());
-
+    .context(builder.context());
 
   // Apply filters to models on the aggregation path
   if (onAggBuild) {
@@ -279,9 +278,8 @@ const applyAggregations = function <M extends BaseModel>(
 
   // Create a replicated subquery equivalent to the base model + aggregations
   const fullQuery = Model.query()
-  	.select(Model.tableName + '.*')
-	.context(builder.context());
-
+    .select(Model.tableName + '.*')
+    .context(builder.context());
 
   // For each aggregation query, select the aggregation then join onto the full query
   aggregationQueries.forEach((query, i) => {
@@ -489,7 +487,7 @@ export function applyRequire<M extends BaseModel>(
 
   // If there are a hasMany or manyToMany relations, then create a separate filter query
   const filterQuery = Model.query()
-  	.distinct(...fullIdColumns)
+    .distinct(...fullIdColumns)
     .context(builder.context());
 
   applyLogicalExpression(filter, filterQuery, false, getFullyQualifiedName);

--- a/test/complex.test.js
+++ b/test/complex.test.js
@@ -96,27 +96,28 @@ describe('complex filters', function () {
           expect(movie.category.name).to.equal('C08');
         });
 
-		it('should pass the builder context to relation modifiers', async () => {
-			// Make a builder with a context to be used in the relation
-			const builder = Person.query();
-			builder.context({ useFirstMovie: () => true })
+        it('should pass the builder context to relation modifiers', async () => {
+          // Make a builder with a context to be used in the relation
+          const builder = Person.query();
+          builder.context({ useFirstMovie: () => true })
 
-			const query = buildFilter(Person, null, { builder });
-			const result = await query
-			  .build({
-				eager: {
-				$where: {
-					'movies.categoryId': 1
-				},
-				movies: true,
-				}
-			  });
-			  expect(result.length).to.equal(1);
-			  const person = result[0];
-			  expect(person.movies.length).to.equal(1);
-			  const movie = person.movies[0];
-			  expect(movie.name).to.equal('M90');
-		  });
+          const query = buildFilter(Person, null, { builder });
+          const result = await query
+            .build({
+              eager: {
+                $where: {
+                  'movies.categoryId': 1
+                },
+                movies: true,
+              }
+            });
+            
+          expect(result.length).to.equal(1);
+          const person = result[0];
+          expect(person.movies.length).to.equal(1);
+          const movie = person.movies[0];
+          expect(movie.name).to.equal('M90');
+        });
 
         context('given there are $or conditions on root and related models (belongsTo)',() => {
           let result;

--- a/test/complex.test.js
+++ b/test/complex.test.js
@@ -96,6 +96,28 @@ describe('complex filters', function () {
           expect(movie.category.name).to.equal('C08');
         });
 
+		it('should pass the builder context to relation modifiers', async () => {
+			// Make a builder with a context to be used in the relation
+			const builder = Person.query();
+			builder.context({ useFirstMovie: () => true })
+
+			const query = buildFilter(Person, null, { builder });
+			const result = await query
+			  .build({
+				eager: {
+				$where: {
+					'movies.categoryId': 1
+				},
+				movies: true,
+				}
+			  });
+			  expect(result.length).to.equal(1);
+			  const person = result[0];
+			  expect(person.movies.length).to.equal(1);
+			  const movie = person.movies[0];
+			  expect(movie.name).to.equal('M90');
+		  });
+
         context('given there are $or conditions on root and related models (belongsTo)',() => {
           let result;
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -194,7 +194,7 @@ module.exports = {
                 numberField: movie.categoryId,
                 booleanField
               },
-        arrayField: booleanField ? [1, 2, 3] : [3, 2, 1],
+              arrayField: booleanField ? [1, 2, 3] : [3, 2, 1],
               nullField: null
             }
           }

--- a/test/utils.js
+++ b/test/utils.js
@@ -301,7 +301,13 @@ function createModels(knex) {
               to: 'Person_Movie.movieId'
             },
             to: 'Movie.id'
-          }
+          },
+		  modify(qb){
+			const { useFirstMovie } = qb.context();
+			if(useFirstMovie && useFirstMovie()){
+				qb.whereRaw('name LIKE ?', 'M_0');
+			}
+		  }
         }
       };
     }

--- a/test/utils.js
+++ b/test/utils.js
@@ -194,7 +194,7 @@ module.exports = {
                 numberField: movie.categoryId,
                 booleanField
               },
-			  arrayField: booleanField ? [1, 2, 3] : [3, 2, 1],
+        arrayField: booleanField ? [1, 2, 3] : [3, 2, 1],
               nullField: null
             }
           }
@@ -302,12 +302,12 @@ function createModels(knex) {
             },
             to: 'Movie.id'
           },
-		  modify(qb){
-			const { useFirstMovie } = qb.context();
-			if(useFirstMovie && useFirstMovie()){
-				qb.whereRaw('name LIKE ?', 'M_0');
-			}
-		  }
+          modify(qb){
+            const { useFirstMovie } = qb.context();
+            if(useFirstMovie && useFirstMovie()){
+              qb.whereRaw('name LIKE ?', 'M_0');
+            }
+          }
         }
       };
     }


### PR DESCRIPTION
#71 
Objection allows relations to specify a `modifier()` in their definition. In some instances, the modifier does not have access to the root builder's context in queries generated by objection-filter. This PR ensures that the modifiers have access to the context in all cases.

One particular example is with a many-to-many relationship, a new query is created from the model instead of the root builder. I added a failing test case using an eager clause with a many-to-many relationship, and a modifier on that relationship. This modifier conditionally runs if a function is passed to the context.  